### PR TITLE
Fix pidfile names

### DIFF
--- a/sysutils/nut/files/nut_upsd.in
+++ b/sysutils/nut/files/nut_upsd.in
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 2 Clause BSD license
 
 BINARY=%%PREFIX%%/sbin/upsd
-PID=/var/db/nut/nut_upsd.pid
+PID=/var/db/nut/upsd.pid
 name="NUT UPS Daemon"
 
 depend() {

--- a/sysutils/nut/files/nut_upslog.in
+++ b/sysutils/nut/files/nut_upslog.in
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 2 Clause BSD license
 
 BINARY=%%PREFIX%%/sbin/upslog
-PID=/var/db/nut/nut_upslog.pid
+PID=/var/db/nut/upslog.pid
 name="NUT UPS Logging Daemon"
 
 depend() {

--- a/sysutils/nut/files/nut_upsmon.in
+++ b/sysutils/nut/files/nut_upsmon.in
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 2 Clause BSD license
 
 BINARY=%%PREFIX%%/sbin/upsmon
-PID=/var/db/nut/nut_upsmon.pid
+PID=/var/db/nut/upsmon.pid
 name="NUT UPS Monitoring Daemon"
 
 depend() {


### PR DESCRIPTION
NUT executables are particular about their pidfile names.  If they are not correct when passed to the openrc start-stop-daemon functions, they will not get deleted on a service stop, so the next service start fails.  I noticed this after updating this morning.