### PR TITLE
Add an openrc script for powerd++

### DIFF
--- a/sysutils/powerdxx/Makefile.trueos
+++ b/sysutils/powerdxx/Makefile.trueos
@@ -1,0 +1,2 @@
+USE_OPENRC_SUBR=        openrc-powerd++
+

--- a/sysutils/powerdxx/files/openrc-powerd++.in
+++ b/sysutils/powerdxx/files/openrc-powerd++.in
@@ -1,0 +1,33 @@
+#!/sbin/openrc-run
+
+name="powerd++: Alternative Power Control Deamon"
+command_args=$powerd_args
+command="/usr/local/sbin/powerd++"
+pidfile="/var/run/powerd.pid"
+
+depend()
+{
+	need localmount
+	use logger
+	after bootmisc
+	keyword -jail -prefix
+}
+
+start_pre()
+{
+	if [ -n "$powerd++_battery_mode" ]; then
+		command_args="$command_args -b $powerd_battery_mode"
+	fi
+	if [ -n "${powerd++_ac_mode}" ]; then
+		command_args="$command_args -a $powerd_ac_mode"
+	fi
+}
+
+stop_post()
+{
+	local level=$(sysctl -n dev.cpu.0.freq_levels |
+	    sed -e 's:/.*::')
+	if [ -n "$level" ]; then
+		sysctl dev.cpu.0.freq="$level" >/dev/null
+	fi
+}


### PR DESCRIPTION
Since this thing is a "drop-in" replacement, I just copied the powerd
openrc script. Grasping for the lowest branch here. Seems to work well
though (and it works on 12.0-current now).