### PR TITLE
Update openrc-vmware-kmod.in

### DIFF
--- a/emulators/open-vm-tools/files/openrc-vmware-kmod.in
+++ b/emulators/open-vm-tools/files/openrc-vmware-kmod.in
@@ -3,7 +3,7 @@
 command="kldstat"
 
 start_pre() {
-	if[ $1 = vmmemctl ]; then
+	if [ $1 = vmmemctl ]; then
 		# VMware kernel module: vmmemctl
 		kernel_mod="vmmemctl"
 		name="vmware_guest_${kernel_mod}"


### PR DESCRIPTION
fixes rc.log:/usr/local/etc/init.d/vmware-kmod: 6: Syntax error: "then" unexpected (expecting "}")